### PR TITLE
Allow to control local size by environment variable

### DIFF
--- a/bluefog/common/mpi_context.cc
+++ b/bluefog/common/mpi_context.cc
@@ -23,7 +23,7 @@
 #include "half.h"
 
 // Bluefog knobs.
-#define NODES_PER_MACHINE "NODES_PER_MACHINE"
+#define BLUEFOG_NODES_PER_MACHINE "BLUEFOG_NODES_PER_MACHINE"
 
 namespace bluefog {
 namespace common {
@@ -317,7 +317,7 @@ void MPIContext::Initialize(const std::vector<int>& ranks,
   MPI_Comm_rank(mpi_comm, &world_rank);
   MPI_Comm_size(mpi_comm, &world_size);
 
-  const char* nodes_per_machine_ptr = std::getenv(NODES_PER_MACHINE);
+  const char* nodes_per_machine_ptr = std::getenv(BLUEFOG_NODES_PER_MACHINE);
   if (nodes_per_machine_ptr == nullptr) {
     // Create local comm, Determine local rank by querying the local
     // communicator.

--- a/bluefog/common/mpi_context.cc
+++ b/bluefog/common/mpi_context.cc
@@ -22,6 +22,9 @@
 #include "timeline.h"
 #include "half.h"
 
+// Bluefog knobs.
+#define NODES_PER_MACHINE "NODES_PER_MACHINE"
+
 namespace bluefog {
 namespace common {
 
@@ -310,13 +313,31 @@ void MPIContext::Initialize(const std::vector<int>& ranks,
     BFLOG(DEBUG) << "Using the existing mpi_comm.";
   }
 
-  // Create local comm, Determine local rank by querying the local communicator.
-  MPI_Comm_split_type(mpi_comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
-                      &local_comm);
+  int world_rank, world_size;
+  MPI_Comm_rank(mpi_comm, &world_rank);
+  MPI_Comm_size(mpi_comm, &world_size);
+
+  const char* nodes_per_machine_ptr = std::getenv(NODES_PER_MACHINE);
+  if (nodes_per_machine_ptr == nullptr) {
+    // Create local comm, Determine local rank by querying the local
+    // communicator.
+    MPI_Comm_split_type(mpi_comm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,
+                        &local_comm);
+  } else {
+    const int local_size = atoi(nodes_per_machine_ptr);
+    if (local_size <= 0) {
+      BFLOG(FATAL) << "The provided NODES_PER_MACHINE must be positive integer.";
+    }
+    if (world_size % local_size) {
+      BFLOG(WARNING) << "The number of world size is not the multiplier of "
+                        "provided NODES_PER_MACHINE";
+    }
+    int machine_rank = world_rank / local_size;
+    MPI_Comm_split(mpi_comm, machine_rank, world_rank, &local_comm);
+  }
 
   // Get local rank and world rank for cross comm establishment.
-  int local_rank, world_rank;
-  MPI_Comm_rank(mpi_comm, &world_rank);
+  int local_rank;
   MPI_Comm_rank(local_comm, &local_rank);
 
   // Create cross node communicator.

--- a/test/torch_basics_test.py
+++ b/test/torch_basics_test.py
@@ -54,7 +54,7 @@ class BasicsTests(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(BasicsTests, self).__init__(*args, **kwargs)
         warnings.simplefilter("module")
-        os.environ['NODES_PER_MACHINE'] = '2'
+        os.environ['BLUEFOG_NODES_PER_MACHINE'] = '2'
 
     def test_bluefog_rank(self):
         """Test that the rank returned by bf.rank() is correct."""

--- a/test/torch_basics_test.py
+++ b/test/torch_basics_test.py
@@ -73,15 +73,16 @@ class BasicsTests(unittest.TestCase):
         assert true_size == size
 
     def test_bluefog_local_size(self):
+        _, true_size = mpi_env_rank_and_size()
         bf.init()
         local_size = bf.local_size()
-        assert local_size == 2
+        assert local_size == min(2, true_size)
 
     def test_bluefog_local_rank(self):
-        true_rank, _ = mpi_env_rank_and_size()
+        true_rank, true_size = mpi_env_rank_and_size()
         bf.init()
         local_rank = bf.local_rank()
-        assert true_rank % 2 == local_rank
+        assert true_rank % min(2, true_size) == local_rank
 
     def test_set_topology_fail_with_win_create(self):
         bf.init()

--- a/test/torch_basics_test.py
+++ b/test/torch_basics_test.py
@@ -18,6 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import inspect
+import os
 import warnings
 import unittest
 
@@ -53,6 +54,7 @@ class BasicsTests(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(BasicsTests, self).__init__(*args, **kwargs)
         warnings.simplefilter("module")
+        os.environ['NODES_PER_MACHINE'] = '2'
 
     def test_bluefog_rank(self):
         """Test that the rank returned by bf.rank() is correct."""
@@ -69,6 +71,17 @@ class BasicsTests(unittest.TestCase):
         size = bf.size()
         # print("Size: ", true_size, size)
         assert true_size == size
+
+    def test_bluefog_local_size(self):
+        bf.init()
+        local_size = bf.local_size()
+        assert local_size == 2
+
+    def test_bluefog_local_rank(self):
+        true_rank, _ = mpi_env_rank_and_size()
+        bf.init()
+        local_rank = bf.local_rank()
+        assert true_rank % 2 == local_rank
 
     def test_set_topology_fail_with_win_create(self):
         bf.init()
@@ -135,8 +148,10 @@ class BasicsTests(unittest.TestCase):
         out_neighbors = bf.out_neighbor_ranks()
 
         degree = int(np.ceil(np.log2(size)))
-        expected_in_neighbors = sorted([(rank - 2 ** i) % size for i in range(degree)])
-        expected_out_neighbors = sorted([(rank + 2 ** i) % size for i in range(degree)])
+        expected_in_neighbors = sorted(
+            [(rank - 2 ** i) % size for i in range(degree)])
+        expected_out_neighbors = sorted(
+            [(rank + 2 ** i) % size for i in range(degree)])
         assert sorted(in_neighbors) == expected_in_neighbors
         assert sorted(out_neighbors) == expected_out_neighbors
 
@@ -148,7 +163,8 @@ class BasicsTests(unittest.TestCase):
         in_neighbors = bf.in_neighbor_ranks()
         out_neighbors = bf.out_neighbor_ranks()
 
-        expected_in_neighbors = list(set(map(lambda x: x % size, [rank - 1, rank + 1])))
+        expected_in_neighbors = list(
+            set(map(lambda x: x % size, [rank - 1, rank + 1])))
         expected_out_neighbors = list(
             set(map(lambda x: x % size, [rank - 1, rank + 1]))
         )


### PR DESCRIPTION
Since NCCL comm is relied on the MPI comm, both comms are supported to control by the environment variable BLUEFOG_NODES_PER_MACHINE.